### PR TITLE
Experimental: Auto-create NFS share

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Unable to create VM (-85377018)
 `docker-machine-xhyve` also `xhyve` does not implement shared folder system.  
 Please use the existing protocol for the time being, such as `NFS`.
 
+`docker-machine-xhyve` can create a `NFS` share automatically for you, but this feature
+is highly experimental. To use it specify `--xhyve-experimental-nfs-share` when creating your
+machine.
+
 ### Get state use `ssh`, do not know real vm state
 `docker-machine-xhyve` checking vm state use send `exit 0` on `ssh`.  
 but, that is not real state of vm.  
@@ -149,3 +153,6 @@ I tested CoreOS and TinyCoreLinux by original `xhyve`,  but also could not be se
 - [ ] Replace generate uuid, native Go code instead of `uuidgen`
 - [ ] Get vm state, xpc or etc.
 - [ ] Cleanup code and more performance
+- [ ] NFS Share
+    - [ ] Validate created `/etc/exports` using `ntpd checkexports` and only overwrite when valid
+    - [ ] Remove from `/etc/exports` on `rm`

--- a/vmnet/vmnet.go
+++ b/vmnet/vmnet.go
@@ -32,7 +32,7 @@ func GetMACAddressByUUID(uuid string) (string, error) {
 	return hw.String(), nil
 }
 
-func getNetAddr() (net.IP, error) {
+func GetNetAddr() (net.IP, error) {
 	out, err := exec.Command("defaults", "read", CONFIG_PLIST, NET_ADDR_KEY).Output()
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func getNetMask() (net.IPMask, error) {
 }
 
 func GetIPNet() (*net.IPNet, error) {
-	ip, err := getNetAddr()
+	ip, err := GetNetAddr()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Auto-create NFS share

Missing:
* Validate created `/etc/exports` using `ntpd checkexports` and only overwrite when valid
* Remove from `/etc/exports` on `rm`

Fixes https://github.com/zchee/docker-machine-xhyve/issues/20

```
$ docker-machine -D create -d xhyve --xhyve-disk-size "2000" --xhyve-experimental-nfs-share xhyve 
```

```
docker@boot2docker:~$ df -h
Filesystem                Size      Used Available Use% Mounted on
tmpfs                   896.6M    123.8M    772.8M  14% /
tmpfs                   498.1M         0    498.1M   0% /dev/shm
/dev/vda1               996.5M      1.8M    926.5M   0% /mnt/vda1
cgroup                  498.1M         0    498.1M   0% /sys/fs/cgroup
192.168.64.1:/Users     111.9G     84.1G     27.5G  75% /Users
/dev/vda1               996.5M      1.8M    926.5M   0% /mnt/vda1/var/lib/docker/aufs
```